### PR TITLE
Remove definicao de termos com sentido e significado comum

### DIFF
--- a/br_mg_estadual_decreto_2012-05-24;45969.md
+++ b/br_mg_estadual_decreto_2012-05-24;45969.md
@@ -110,10 +110,6 @@ XVIII – reclassificação: alteração, pela autoridade competente, da classif
 
 XIX – rol de documentos, dados e informações sigilosas e pessoais: relação anual, a ser publicada pelas autoridades máximas de órgãos e entidades, de documentos, dados e informações classificadas, no período, como sigilosas ou pessoais, com identificação para referência futura;
 
-XX – serviço ou atendimento presencial: aquele prestado na presença física do cidadão, principal beneficiário ou interessado no serviço;
-
-XXI – serviço ou atendimento eletrônico: aquele prestado remotamente ou à distância, utilizando meios eletrônicos de comunicação;
-
 XXII – tabela de documentos, dados e informações sigilosas e pessoais: relação exaustiva de documentos, dados e informações com qualquer restrição de acesso, com a indicação do grau de sigilo, decorrente de estudos e pesquisas promovidos pelas Comissões de Gestão de Informação, e publicada pelas autoridades máximas dos órgãos e entidades; e
 
 XXIII – tratamento da informação: conjunto de ações referentes à produção, recepção, classificação, utilização, acesso, reprodução, transporte, transmissão, distribuição, arquivamento, armazenamento, eliminação, avaliação, destinação ou controle da informação.


### PR DESCRIPTION
Conselho do GESPÚBLICA no documento [Fugindo do “burocratês”: como facilitar o acesso do
cidadão ao serviço público](http://www.gespublica.gov.br/sites/default/files/documentos/linguagem_cidada_-_versao_final_web.pdf#page=6)

> Evite ter que explicar termos. Procure usar, sempre que possível, termos de amplo conhecimento do seu público-alvo, para que assim você não precise acrescentar ao texto definições. Definições causam, na maioria das vezes, mais problemas do que trazem soluções para seu texto.

Esse documento parece influenciado pelo conselhos de [plain language](https://www.plainlanguage.gov/guidelines/words/minimize-definitions/).